### PR TITLE
Add extension name to openssl x509 command

### DIFF
--- a/createPrivateCA/generate-certs.sh
+++ b/createPrivateCA/generate-certs.sh
@@ -46,7 +46,7 @@ function signCert {
 	local COMMON_NAME=$1
 	openssl x509 -req -in public/"${COMMON_NAME}".csr -CA ca/rootCA.crt -CAkey ca/rootCA.key \
 	-CAcreateserial -out public/"${COMMON_NAME}".crt -days 10000 \
-	-extfile public/"${COMMON_NAME}".cnf
+	-extfile public/"${COMMON_NAME}".cnf -extensions req_ext
 }
 
 function main {


### PR DESCRIPTION
This is to stop you from needing to modify global openssl config to run the script to generate SANs, as without this flag the openssl command won't add SANs into the certificate.